### PR TITLE
fix: use node v22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Install dependencies
         working-directory: frontend
@@ -34,3 +34,15 @@ jobs:
       - name: Run prettier
         working-directory: frontend
         run: npm run format
+
+      - name: Build Dockerfile
+        working-directory: frontend
+        run: |
+          if [ -f "Dockerfile" ]; then
+            echo "Dockerfile found. Building the Docker image..."
+            docker build -t your-image-name:latest .
+          else
+            echo "No Dockerfile found. Skipping Docker build."
+          fi
+        env:
+          DOCKER_BUILDKIT: 1

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y curl npm
 WORKDIR /app
 
 RUN npm install -g n
-RUN n install v18
+RUN n install v22
 
 COPY package.json package-lock.json ./
 RUN npm ci

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,10 +10,10 @@ nvm -v
 ```
 Para o comando acima funcionar você precisa ter o **curl** instalado. No windows e mac se instala o nvm de outra forma.
 
-Instale e use o node v18
+Instale e use o node v22
 ```bash
-nvm install v18
-nvm use v18
+nvm install v22
+nvm use v22
 node -v
 ```
 


### PR DESCRIPTION
Front-end libraries often require Node.js v18+, necessitating an early version update to preempt compatibility issues. 