### PR TITLE
Padronização das rotas de eventos e periódicos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 frontend/node_modules/
 backend/docker-volumes/postgres-vol
 .vscode/
+.idea/

--- a/backend/endpoint.md
+++ b/backend/endpoint.md
@@ -195,25 +195,37 @@ X-User-Id: <UUID do usuário solicitante>
 
 ---
 
-# 📘 API - Cadastro de Evento
+# 📘 API - Evento
+
+Base URL:
+
+```
+/api/eventos
+```
+
+## ➕ 1. **Cadastrar Evento**
 
 **Endpoint:**
+
 ```
-POST /api/eventos/cadastro/
+POST /api/eventos
 ```
 
 **Descrição:**  
-Cria um novo evento no sistema, *deve ser um usuario já cadastrado no sistema*.
+Cria um novo evento no sistema, _deve ser um usuario já cadastrado no sistema_.
 
 **Headers obrigatórios:**
+
 ```http
 X-User-Id: <UUID do usuário que está tentando aprovar>
 ```
 
 **Path Parameters:**
+
 - `id` – UUID do usuário que está tentando inserir o evento.
 
 **Resposta:**
+
 - `202 Accepted` – Evento criado com sucesso.
 - `409 Conflit` – Tentativa de cadastrar um evento ja cadastrado, duplicação de evento.
 - `400 Bad Request` – Erro na requisição.
@@ -240,6 +252,7 @@ X-User-Id: <UUID do usuário que está tentando aprovar>
 ```
 
 ### Campos:
+
 - `nome` (string): Nome do evento.
 - `vinculoSbc` (string): Tipo de vinculo com a sbc (Enum = "sem_vinculo", "vinculo_top_10", "vinculo_top_20", "vinculo_comum" ).
 - `areasPesquisaIds`(array de UUIDs): IDs das áreas de pesquisa associadas ao evento.
@@ -247,6 +260,7 @@ X-User-Id: <UUID do usuário que está tentando aprovar>
 - `linkEvento` (string): Link do evento o qual está sendo inserido.
 - `linkGoogleScholar` (string) : Link do googlescholar referente ao evento o qual está sendo inserido
 - `linkSolSbc` (string) : Link repositório SOL-SBC referente ao evento o qual está sendo inserido.
+
 ---
 
 ## ✅ Resposta
@@ -279,6 +293,7 @@ X-User-Id: <UUID do usuário que está tentando aprovar>
 ```
 
 ### Campos:
+
 - `idVeiculo` (UUID): Identificador único do evento criado.
 - `nome` , `vinculoSbc`: Mesmos campos enviados, com confirmação do que foi salvo.
 - `classificacao`, `adequacaoDefesa` : a8, nenhum como padrão, no entanto ainda será modificado atraves de calculos. Será implementado a partir de outras RFS.
@@ -286,7 +301,7 @@ X-User-Id: <UUID do usuário que está tentando aprovar>
 - `h5`, `linkEvento`, `linkGoogleScholar`, `linkSolSbc` , `areaPesquisaIds`: Mesmos campos enviados, com confirmação do que foi salvo.
 - `usuario` : Informação de Id e Nome do usuário o qual inseriu Evento.
 
-### Forçar inserção mesmo com erro de duplicação : 
+### Forçar inserção mesmo com erro de duplicação :
 
 ```
 POST /api/eventos/cadastro?forcar=true
@@ -294,25 +309,39 @@ POST /api/eventos/cadastro?forcar=true
 
 ---
 
-# 📘 API - Cadastro de Periodico
+# 📘 API - Periodico
+
+Base URL:
+
+```
+/api/periodicos
+```
+
+---
+
+## ➕ 1. **Cadastrar Periodico**
 
 **Endpoint:**
+
 ```
-POST /api/periodicos/cadastro
+POST /api/periodicos
 ```
 
 **Descrição:**  
-Cria um novo periódico no sistema, *deve ser um usuario já cadastrado no sistema*.
+Cria um novo periódico no sistema, _deve ser um usuario já cadastrado no sistema_.
 
 **Headers obrigatórios:**
+
 ```http
 X-User-Id: <UUID do usuário que está tentando aprovar>
 ```
 
 **Path Parameters:**
+
 - `id` – UUID do usuário que está tentando inserir o evento.
 
 **Resposta:**
+
 - `202 Accepted` – Evento criado com sucesso.
 - `409 Conflit` – Tentativa de cadastrar um evento ja cadastrado, duplicação de evento.
 - `400 Bad Request` – Erro na requisição.
@@ -341,17 +370,19 @@ X-User-Id: <UUID do usuário que está tentando aprovar>
 ```
 
 ### Campos:
+
 - `nome` (string): Nome do evento.
 - `vinculoSbc` (string): Tipo de vinculo com a sbc (Enum = "sem_vinculo", "vinculo_top_10", "vinculo_top_20", "vinculo_comum" ).
-- `issn` (string): Número Internacional Normalizado para Publicações Seriadas, limitado a 8 números. Deve ser único em cada cadastro, acusa duplicação. 
+- `issn` (string): Número Internacional Normalizado para Publicações Seriadas, limitado a 8 números. Deve ser único em cada cadastro, acusa duplicação.
 - `percentilJcr` (Integer): Valor numérico.
 - `percentilScopus` (Integer): Valor numérico.
 - `linkJrc` (string) : Link do Jrc referente ao periódico o qual está sendo inserido
 - `linkScopus` (string) : Link repositório Scopus referente ao periodico o qual está sendo inserido.
-- `classificacao` (string) : Classificação do veículo (Enum = "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8") 
+- `classificacao` (string) : Classificação do veículo (Enum = "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8")
 - `linkGoogleScholar` (string) : Link do googlescholar referente ao periódico o qual está sendo inserido
 - `qualisAntigo` (string) : Pontuação do Qualis antigo (Enum= "a1", "a2", "b1", "b2", "b3", "b4", "b5', "c").
 - `areasPesquisaIds`(array de UUIDs): IDs das áreas de pesquisa associadas ao evento.
+
 ---
 
 ## ✅ Resposta
@@ -387,6 +418,7 @@ X-User-Id: <UUID do usuário que está tentando aprovar>
 ```
 
 ### Campos:
+
 - `idVeiculo` (UUID): Identificador único do evento criado.
 - `nome` , `vinculoSbc`: Mesmos campos enviados, com confirmação do que foi salvo.
 - `adequacaoDefesa` : a8, nenhum como padrão, no entanto ainda será modificado atraves de calculos. Será implementado a partir de outras RFS.
@@ -399,8 +431,7 @@ X-User-Id: <UUID do usuário que está tentando aprovar>
 ```
 POST /api/periodicos/cadastro?forcar=true
 ```
+
 ---
-
-
 
 

--- a/backend/src/main/java/com/acadmap/controller/EventoController.java
+++ b/backend/src/main/java/com/acadmap/controller/EventoController.java
@@ -3,15 +3,20 @@ package com.acadmap.controller;
 import com.acadmap.model.dto.evento.EventoCreateDTO;
 import com.acadmap.model.dto.evento.EventoResponseDTO;
 import com.acadmap.service.CriarEventoService;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.UUID;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/eventos/cadastro")
+@RequestMapping("/api/eventos")
 @AllArgsConstructor
 @CrossOrigin(origins = "*")
 public class EventoController {
@@ -20,8 +25,8 @@ public class EventoController {
 
   @PostMapping
   public ResponseEntity<EventoResponseDTO> criarEvento(@RequestBody EventoCreateDTO dto,
-                                                       @RequestHeader("X-User-Id") UUID idUser,
-                                                       @RequestParam(defaultValue = "false") boolean forcar) {
+      @RequestHeader("X-User-Id") UUID idUser,
+      @RequestParam(defaultValue = "false") boolean forcar) {
     EventoResponseDTO dtoreponseevento = this.criarEventoService.criarEvento(dto, idUser, forcar);
     return ResponseEntity.status(HttpStatus.CREATED).body(dtoreponseevento);
   }

--- a/backend/src/main/java/com/acadmap/controller/PeriodicoController.java
+++ b/backend/src/main/java/com/acadmap/controller/PeriodicoController.java
@@ -2,47 +2,56 @@ package com.acadmap.controller;
 
 
 import com.acadmap.model.dto.periodico.ClassificacaoPeriodicoRequestDTO;
-import com.acadmap.model.dto.periodico.PeriodicoResponseDTO;
 import com.acadmap.model.dto.periodico.PeriodicoRequestDTO;
+import com.acadmap.model.dto.periodico.PeriodicoResponseDTO;
 import com.acadmap.model.entities.Periodico;
 import com.acadmap.service.ClassificarPeriodicoService;
 import com.acadmap.service.CriarPeriodicoService;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.UUID;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("api/periodicos/cadastro")
+@RequestMapping("/api/periodicos")
 @AllArgsConstructor
 @CrossOrigin(origins = "*")
 public class PeriodicoController {
 
-    private final CriarPeriodicoService criarPeriodicoService;
-    private final ClassificarPeriodicoService classificarPeriodicoService;
+  private final CriarPeriodicoService criarPeriodicoService;
+  private final ClassificarPeriodicoService classificarPeriodicoService;
 
-    @PostMapping
-    public ResponseEntity<PeriodicoResponseDTO> criarPeriodico(@RequestBody PeriodicoRequestDTO dto,
-                                                               @RequestHeader("X-User-Id") UUID idUser,
-                                                               @RequestParam(defaultValue = "false") boolean forcar) {
-        System.out.println("FORCAR: " + forcar);
-        PeriodicoResponseDTO dtoresponseperiodico = this.criarPeriodicoService.criarPeriodico(dto, idUser, forcar);
-        return ResponseEntity.status(HttpStatus.CREATED).body(dtoresponseperiodico);
-    }
+  @PostMapping
+  public ResponseEntity<PeriodicoResponseDTO> criarPeriodico(@RequestBody PeriodicoRequestDTO dto,
+      @RequestHeader("X-User-Id") UUID idUser,
+      @RequestParam(defaultValue = "false") boolean forcar) {
+    System.out.println("FORCAR: " + forcar);
+    PeriodicoResponseDTO dtoresponseperiodico =
+        this.criarPeriodicoService.criarPeriodico(dto, idUser, forcar);
+    return ResponseEntity.status(HttpStatus.CREATED).body(dtoresponseperiodico);
+  }
 
-    @PatchMapping("/{idPeriodico}/classificar")
-    @Deprecated
-    public ResponseEntity<PeriodicoResponseDTO> classificarPeriodico(@PathVariable UUID idPeriodico,
-                                                                     @RequestBody ClassificacaoPeriodicoRequestDTO classificacaoPeriodicoRequestDTO,
-                                                                     @RequestHeader("X-User-Id") UUID idUser) {
-        System.out.println(idUser);
-        Periodico periodicoAtualizado = classificarPeriodicoService.classificarPeriodico(idPeriodico, classificacaoPeriodicoRequestDTO, idUser);
+  @PatchMapping("/{idPeriodico}/classificar")
+  @Deprecated
+  public ResponseEntity<PeriodicoResponseDTO> classificarPeriodico(@PathVariable UUID idPeriodico,
+      @RequestBody ClassificacaoPeriodicoRequestDTO classificacaoPeriodicoRequestDTO,
+      @RequestHeader("X-User-Id") UUID idUser) {
+    System.out.println(idUser);
+    Periodico periodicoAtualizado = this.classificarPeriodicoService
+        .classificarPeriodico(idPeriodico, classificacaoPeriodicoRequestDTO, idUser);
 
-        PeriodicoResponseDTO periodicoResponseDTO = new PeriodicoResponseDTO(periodicoAtualizado);
+    PeriodicoResponseDTO periodicoResponseDTO = new PeriodicoResponseDTO(periodicoAtualizado);
 
-        return ResponseEntity.ok(periodicoResponseDTO);
-    }
+    return ResponseEntity.ok(periodicoResponseDTO);
+  }
 }
 


### PR DESCRIPTION
### O que foi feito
- Alteradas as rotas:
  - `/api/eventos/cadastro` → `/api/eventos`
  - `/api/periodicos/cadastro` → `/api/periodicos`
- Atualizada a documentação para refletir as novas URLs.

### Motivação
As rotas foram simplificadas e padronizadas para seguir boas práticas REST, permitindo que os controllers sejam mais genéricos, já que não tratam apenas de cadastro.

### Impacto
É necessário ajustar os consumidores da API para usar as novas rotas.
