### PR TITLE
Feat/add filtros pesquisa veiculos

### DIFF
--- a/backend/endpoint.md
+++ b/backend/endpoint.md
@@ -382,128 +382,55 @@ Status: `404 NOT FOUND`
 | 404    | Evento não encontrado                     |
 
 ---
-
-
-## 📋 3. **Listar Eventos Aprovados**
-
-**Endpoint:**
-```
-
-GET /api/eventos/listar
-
-```
-
-**Descrição:** Retorna uma lista resumida de todos os eventos com status 'aceito', ideal para a visualização pública (RF03).
-
-**Query Parameters:**
-- `nome` (string, opcional) - Filtra a lista para retornar apenas eventos cujo nome contenha o texto informado (busca parcial e case-insensitive).
-
-### ✅ **Exemplo de uso**
-```
-
-GET /api/eventos/listar?nome=Symposium
-
-````
-
----
-
-### ✅ **Resposta de Sucesso (200 OK)**
-Retorna uma lista de eventos resumidos. Se nenhum filtro for aplicado, retorna todos os eventos aprovados. Se nenhum evento for encontrado, retorna uma lista vazia `[]`.
-
-```json
-[
-  {
-    "idVeiculo": "99999999-dddd-dddd-dddd-dddddddddddd",
-    "nome": "Symposium on Distributed Computing",
-    "classificacao": "a2",
-    "h5": 50,
-    "adequacaoDefesa": "doutorado",
-    "vinculoSBC": "vinculo_top_10",
-    "areaPesquisa": [
-      "Ciência da Computação",
-      "Engenharia Elétrica"
-    ]
-  },
-  {
-    "idVeiculo": "11111111-1111-1111-1111-111111111109",
-    "nome": "Linux Kernel Summit",
-    "classificacao": "a2",
-    "h5": 55,
-    "adequacaoDefesa": "mestrado_doutorado",
-    "vinculoSBC": "vinculo_comum",
-    "areaPesquisa": [
-      "Ciência da Computação"
-    ]
-  }
-]
-````
-
------
-
-### ✅ **Códigos de resposta**
-
-| Código | Descrição                                 |
-|--------|-------------------------------------------|
-| 200    | Lista de eventos retornada com sucesso.   |
-| 500    | Erro interno no servidor.                 |
-
-````
-
----
-
-### 2. Documentação para Listar Periódicos
-
-**Instrução:** Adicione o seguinte texto ao final da seção **`# 📘 API - Periodico`** no seu arquivo `endpoint.md`.
-
-```markdown
----
- ## 📋 3. **Listar Periódicos Aprovados**
-
+# 📋 3. Listar e Filtrar Eventos Aprovados
 **Endpoint:**
 
-````
-
-GET /api/periodicos/listar
-
+```
+POST /api/eventos/listar
 ```
 
-**Descrição:** Retorna uma lista resumida de todos os periódicos com status 'aceito', ideal para a visualização pública (RF03). Inclui uma flag para identificar periódicos predatórios.
+**Descrição:**
 
-**Query Parameters:**
-- `nome` (string, opcional) - Filtra a lista para retornar apenas periódicos cujo nome contenha o texto informado (busca parcial e case-insensitive).
-
-### ✅ **Exemplo de uso**
-```
-
-GET /api/periodicos/listar?nome=Journal
-
-````
+Retorna uma lista resumida de todos os eventos com status 'aceito', com base num conjunto complexo de filtros enviados no corpo da requisição. Se um corpo vazio ou nulo for enviado, retorna todos os veículos aprovados. Este endpoint substitui o antigo GET /listar.
 
 ---
+### 🔸 Requisição
 
-### ✅ **Resposta de Sucesso (200 OK)**
-Retorna uma lista de periódicos resumidos. Se nenhum filtro for aplicado, retorna todos os periódicos aprovados. Se nenhum periódico for encontrado, retorna uma lista vazia `[]`.
+**Content-Type:** application/json
 
-```json
-[
-  {
-    "idVeiculo": "55555555-5555-5555-5555-555555555555",
-    "nome": "Journal of Advanced AI",
-    "tipo": "periodico",
-    "classificacao": "a1",
-    "flagPredatorio": false
-  },
-  {
-    "idVeiculo": "11111111-1111-1111-1111-111111111101",
-    "nome": "The Art of Computer Programming Journal",
-    "tipo": "periodico",
-    "classificacao": "a1",
-    "flagPredatorio": false
-  }
-]
-````
+Corpo (Body) esperado:
+```
+O corpo da requisição é um objeto JSON onde todos os campos são opcionais.
+```
+Exemplo de Corpo (Body):
 
------
+```
+JSON
+
+{
+"nome": "Conference",
+"areasPesquisaNomes": ["Ciência da Computação", "Engenharia Elétrica"],
+"vinculoSbc": true,
+"adequacaoDefesa": ["MESTRADO", "DOUTORADO"],
+"h5Minimo": 50,
+"classificacaoMinima": "a2",
+"correspondenciaExata": false
+}
+
+```
+Campos do Filtro:
+
+- ``nome (string)``: Filtra veículos cujo nome contenha o texto informado.
+- ``areasPesquisaNomes (array de strings)``: Retorna veículos que pertençam a pelo menos uma das áreas de pesquisa listadas.
+- ``vinculoSbc (boolean)``:
+  - ``true``: Retorna apenas veículos que possuem algum vínculo com a SBC.
+  - ``false``: Retorna apenas veículos sem vínculo com a SBC.
+- ``adequacaoDefesa (array de strings)``: Retorna veículos adequados para as defesas listadas. Valores possíveis no Enum: "MESTRADO", "DOUTORADO", "MESTRADO_DOUTORADO", "NENHUM".
+- ``h5Minimo (integer)``: Retorna veículos com índice H5 igual ou superior ao valor especificado.
+- ``classificacaoMinima (string)``: Retorna veículos com classificação igual ou superior à especificada. A ordem é: a8 (mais baixa) até a1 (mais alta). Valores possíveis: "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8".
+- ``correspondenciaExata (boolean)``: Define como os filtros são combinados.
+  - ``false (padrão)``: Lógica OR (inclusiva). Retorna veículos que correspondam a qualquer um dos filtros preenchidos.
+  - ``true``: Lógica AND (excludente). Retorna veículos que correspondam a todos os filtros preenchidos.
 
 ### ✅ **Códigos de resposta**
 
@@ -511,6 +438,9 @@ Retorna uma lista de periódicos resumidos. Se nenhum filtro for aplicado, retor
 |--------|----------------------------------------------|
 | 200    | Lista de periódicos retornada com sucesso.   |
 | 500    | Erro interno no servidor.                    |
+Nota para Desenvolvedores: O antigo endpoint GET /listar?nome=... foi marcado como obsoleto (@Deprecated) no backend. Ele continua a funcionar por retrocompatibilidade, mas todo o novo desenvolvimento deve usar o endpoint POST /listar com o corpo JSON.
+
+---
 
 # 📘 API - Periodico
 
@@ -717,64 +647,55 @@ Status: `400 BAD REQUEST`
 | 404    | Periódico não encontrado                     |
 
 ---
- ## 📋 3. **Listar Periódicos Aprovados**
-
+# 📋 3. Listar e Filtrar Periódicos Aprovados
 **Endpoint:**
 
 ```
-
-GET /api/periodicos/listar
-
+POST /api/periodicos/listar
 ```
 
-**Descrição:** Retorna uma lista resumida de todos os periódicos com status 'aceito', ideal para a visualização pública (RF03). Inclui uma flag para identificar periódicos predatórios.
+**Descrição:** 
 
-**Query Parameters:**
-- `nome` (string, opcional) - Filtra a lista para retornar apenas periódicos cujo nome contenha o texto informado (busca parcial e case-insensitive).
-
-### ✅ **Exemplo de uso**
-```
-
-GET /api/periodicos/listar?nome=Journal
-
-````
+Retorna uma lista resumida de todos os periódicos com status 'aceito', com base num conjunto complexo de filtros enviados no corpo da requisição. Se um corpo vazio ou nulo for enviado, retorna todos os veículos aprovados. Este endpoint substitui o antigo GET /listar.
 
 ---
+## 🔸 Requisição
 
-### ✅ **Resposta de Sucesso (200 OK)**
-Retorna uma lista de periódicos resumidos. Se nenhum filtro for aplicado, retorna todos os periódicos aprovados. Se nenhum periódico for encontrado, retorna uma lista vazia `[]`.
+**Content-Type:** application/json
 
-```json
-[
-  {
-    "idVeiculo": "55555555-5555-5555-5555-555555555555",
-    "nome": "Journal of Advanced AI",
-    "classificacao": "a1",
-    "flagPredatorio": false,
-    "h5": 10,
-    "adequacaoDefesa": "doutorado",
-    "vinculoSBC": "vinculo_top_10",
-    "areaPesquisa": [
-      "Ciência da Computação",
-      "Engenharia Elétrica"
-    ]
-  },
-  {
-    "idVeiculo": "11111111-1111-1111-1111-111111111101",
-    "nome": "The Art of Computer Programming Journal",
-    "classificacao": "a1",
-    "flagPredatorio": false,
-    "h5": null,
-    "adequacaoDefesa": "doutorado",
-    "vinculoSBC": "vinculo_top_10",
-    "areaPesquisa": [
-      "Ciência da Computação"
-    ]
-  }
-]
-````
+Corpo (Body) esperado:
+```
+O corpo da requisição é um objeto JSON onde todos os campos são opcionais.
+```
+Exemplo de Corpo (Body):
 
------
+```
+JSON
+
+{
+"nome": "Conference",
+"areasPesquisaNomes": ["Ciência da Computação", "Engenharia Elétrica"],
+"vinculoSbc": true,
+"adequacaoDefesa": ["MESTRADO", "DOUTORADO"],
+"h5Minimo": 50,
+"classificacaoMinima": "a2",
+"correspondenciaExata": false
+}
+
+```
+Campos do Filtro:
+
+- ``nome (string)``: Filtra veículos cujo nome contenha o texto informado.
+- ``areasPesquisaNomes (array de strings)``: Retorna veículos que pertençam a pelo menos uma das áreas de pesquisa listadas.
+- ``vinculoSbc (boolean)``:
+  - ``true``: Retorna apenas veículos que possuem algum vínculo com a SBC.
+  - ``false``: Retorna apenas veículos sem vínculo com a SBC.
+- ``adequacaoDefesa (array de strings)``: Retorna veículos adequados para as defesas listadas. Valores possíveis no Enum: "MESTRADO", "DOUTORADO", "MESTRADO_DOUTORADO", "NENHUM".
+- ``h5Minimo (integer)``: Retorna veículos com índice H5 igual ou superior ao valor especificado.
+- ``classificacaoMinima (string)``: Retorna veículos com classificação igual ou superior à especificada. A ordem é: a8 (mais baixa) até a1 (mais alta). Valores possíveis: "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8".
+- ``correspondenciaExata (boolean)``: Define como os filtros são combinados.
+  - ``false (padrão)``: Lógica OR (inclusiva). Retorna veículos que correspondam a qualquer um dos filtros preenchidos.
+  - ``true``: Lógica AND (excludente). Retorna veículos que correspondam a todos os filtros preenchidos.
 
 ### ✅ **Códigos de resposta**
 
@@ -782,3 +703,4 @@ Retorna uma lista de periódicos resumidos. Se nenhum filtro for aplicado, retor
 |--------|----------------------------------------------|
 | 200    | Lista de periódicos retornada com sucesso.   |
 | 500    | Erro interno no servidor.                    |
+Nota para Desenvolvedores: O antigo endpoint GET /listar?nome=... foi marcado como obsoleto (@Deprecated) no backend. Ele continua a funcionar por retrocompatibilidade, mas todo o novo desenvolvimento deve usar o endpoint POST /listar com o corpo JSON.

--- a/backend/src/main/java/com/acadmap/controller/EventoController.java
+++ b/backend/src/main/java/com/acadmap/controller/EventoController.java
@@ -3,6 +3,7 @@ package com.acadmap.controller;
 import com.acadmap.model.dto.evento.EventoCreateDTO;
 import com.acadmap.model.dto.evento.EventoResponseDTO;
 import com.acadmap.model.dto.evento.EventoVisualizacaoDTO;
+import com.acadmap.model.dto.veiculo.FiltroVeiculoRequestDTO;
 import com.acadmap.model.dto.evento.EventoResumoListaDTO;
 import com.acadmap.service.CriarEventoService;
 import com.acadmap.service.EventoConsultaService;
@@ -46,6 +47,14 @@ public class EventoController {
     return ResponseEntity.status(HttpStatus.OK).body(eventoDto);
   }
 
+  @PostMapping("/listar")
+  public ResponseEntity<List<EventoResumoListaDTO>> listarComFiltros(@RequestBody(required = false) FiltroVeiculoRequestDTO filtro) {
+    FiltroVeiculoRequestDTO filtroTratado = (filtro == null) ? new FiltroVeiculoRequestDTO() : filtro;
+    List<EventoResumoListaDTO> eventos = eventoConsultaService.listarComFiltros(filtroTratado);
+    return ResponseEntity.ok(eventos);
+  }
+
+  @Deprecated
   @GetMapping("/listar")
   public ResponseEntity<List<EventoResumoListaDTO>> listarEventosAprovados(
           @RequestParam(required = false) String nome) {

--- a/backend/src/main/java/com/acadmap/controller/PeriodicoController.java
+++ b/backend/src/main/java/com/acadmap/controller/PeriodicoController.java
@@ -2,6 +2,7 @@ package com.acadmap.controller;
 
 
 import com.acadmap.model.dto.periodico.*;
+import com.acadmap.model.dto.veiculo.FiltroVeiculoRequestDTO;
 import com.acadmap.model.entities.Periodico;
 import com.acadmap.model.entities.VeiculoPublicacao;
 import com.acadmap.repository.VeiculoPublicacaoRepository;
@@ -65,6 +66,14 @@ public class PeriodicoController {
     return ResponseEntity.status(HttpStatus.OK).body(periodicoDto);
   }
 
+  @PostMapping("/listar")
+    public ResponseEntity<List<PeriodicoResumoListaDTO>> listarComFiltros(@RequestBody(required = false) FiltroVeiculoRequestDTO filtro) {
+        FiltroVeiculoRequestDTO filtroTratado = (filtro == null) ? new FiltroVeiculoRequestDTO() : filtro;
+        List<PeriodicoResumoListaDTO> periodicos = periodicoConsultaService.listarComFiltros(filtroTratado);
+        return ResponseEntity.ok(periodicos);
+    }
+
+  @Deprecated
   @GetMapping("/listar")
   public ResponseEntity<List<PeriodicoResumoListaDTO>> listarPeriodicosAprovados(
           @RequestParam(required = false) String nome) {

--- a/backend/src/main/java/com/acadmap/model/dto/veiculo/FiltroVeiculoRequestDTO.java
+++ b/backend/src/main/java/com/acadmap/model/dto/veiculo/FiltroVeiculoRequestDTO.java
@@ -1,0 +1,32 @@
+package com.acadmap.model.dto.veiculo;
+
+import com.acadmap.model.enums.AdequacaoDefesa;
+import com.acadmap.model.enums.ClassificacaoVeiculo;
+import com.acadmap.model.enums.VinculoSBC;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Set;
+import java.util.UUID;
+
+@Getter
+@Setter
+public class FiltroVeiculoRequestDTO {
+
+    private String nome;
+
+    private Set<UUID> areasPesquisaIds;
+
+    private Set<String> areasPesquisaNomes;
+
+    private Boolean vinculoSbc;
+
+    private Set<AdequacaoDefesa> adequacaoDefesa;
+
+    private Integer h5Minimo;
+
+    private ClassificacaoVeiculo classificacaoMinima;
+
+    //AND (true) ou OR (false)
+    private boolean correspondenciaExata = false;
+}

--- a/backend/src/main/java/com/acadmap/repository/EventoRepository.java
+++ b/backend/src/main/java/com/acadmap/repository/EventoRepository.java
@@ -1,6 +1,7 @@
 package com.acadmap.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import com.acadmap.model.enums.StatusVeiculo;
 import org.springframework.stereotype.Repository;
 import com.acadmap.model.entities.Evento;
@@ -8,7 +9,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Repository
-public interface EventoRepository extends JpaRepository<Evento, UUID> {
+public interface EventoRepository extends JpaRepository<Evento, UUID>, JpaSpecificationExecutor<Evento> {
 
     List<Evento> findByStatus(StatusVeiculo statusVeiculo);
 

--- a/backend/src/main/java/com/acadmap/repository/PeriodicoRepository.java
+++ b/backend/src/main/java/com/acadmap/repository/PeriodicoRepository.java
@@ -3,11 +3,12 @@ package com.acadmap.repository;
 import com.acadmap.model.entities.Periodico;
 import com.acadmap.model.enums.StatusVeiculo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface PeriodicoRepository extends JpaRepository<Periodico, UUID> {
+public interface PeriodicoRepository extends JpaRepository<Periodico, UUID>, JpaSpecificationExecutor<Periodico> {
 
     List<Periodico> findByStatus(StatusVeiculo statusVeiculo);
 

--- a/backend/src/main/java/com/acadmap/service/EventoConsultaService.java
+++ b/backend/src/main/java/com/acadmap/service/EventoConsultaService.java
@@ -1,7 +1,9 @@
 package com.acadmap.service;
 
 import com.acadmap.model.dto.evento.EventoVisualizacaoDTO;
+import com.acadmap.model.dto.veiculo.FiltroVeiculoRequestDTO;
 import com.acadmap.model.entities.Evento;
+import com.acadmap.model.entities.VeiculoPublicacao;
 import com.acadmap.model.enums.StatusVeiculo;
 import com.acadmap.repository.EventoRepository;
 import com.acadmap.model.dto.evento.EventoResumoListaDTO;
@@ -11,7 +13,9 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.acadmap.specification.VeiculoSpecification;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -20,6 +24,7 @@ import org.springframework.web.server.ResponseStatusException;
 @RequiredArgsConstructor
 public class EventoConsultaService {
   private final EventoRepository eventoRepository;
+  private final VeiculoSpecification veiculoSpecification;
 
   public EventoVisualizacaoDTO consultaPorId(UUID id) {
     Optional<Evento> eventoOpt = this.eventoRepository.findById(id);
@@ -49,4 +54,14 @@ public class EventoConsultaService {
             .collect(Collectors.toList());
   }
 
+  public List<EventoResumoListaDTO> listarComFiltros(FiltroVeiculoRequestDTO filtro) {
+
+    Specification<Evento> eventoSpec = veiculoSpecification.getSpecification(filtro);
+
+    List<Evento> eventos = eventoRepository.findAll(eventoSpec);
+
+    return eventos.stream()
+            .map(EventoResumoListaDTO::new)
+            .collect(Collectors.toList());
+  }
 }

--- a/backend/src/main/java/com/acadmap/service/EventoConsultaService.java
+++ b/backend/src/main/java/com/acadmap/service/EventoConsultaService.java
@@ -3,7 +3,6 @@ package com.acadmap.service;
 import com.acadmap.model.dto.evento.EventoVisualizacaoDTO;
 import com.acadmap.model.dto.veiculo.FiltroVeiculoRequestDTO;
 import com.acadmap.model.entities.Evento;
-import com.acadmap.model.entities.VeiculoPublicacao;
 import com.acadmap.model.enums.StatusVeiculo;
 import com.acadmap.repository.EventoRepository;
 import com.acadmap.model.dto.evento.EventoResumoListaDTO;
@@ -13,7 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import com.acadmap.specification.VeiculoSpecification;
+import com.acadmap.service.specification.VeiculoSpecification;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;

--- a/backend/src/main/java/com/acadmap/service/PeriodicoConsultaService.java
+++ b/backend/src/main/java/com/acadmap/service/PeriodicoConsultaService.java
@@ -6,7 +6,7 @@ import com.acadmap.model.dto.veiculo.FiltroVeiculoRequestDTO;
 import com.acadmap.model.entities.Periodico;
 import com.acadmap.model.enums.StatusVeiculo;
 import com.acadmap.repository.PeriodicoRepository;
-import com.acadmap.specification.VeiculoSpecification;
+import com.acadmap.service.specification.VeiculoSpecification;
 
 import java.util.List;
 import java.util.Optional;

--- a/backend/src/main/java/com/acadmap/service/PeriodicoConsultaService.java
+++ b/backend/src/main/java/com/acadmap/service/PeriodicoConsultaService.java
@@ -2,9 +2,11 @@ package com.acadmap.service;
 
 import com.acadmap.model.dto.periodico.PeriodicoResumoListaDTO;
 import com.acadmap.model.dto.periodico.PeriodicoVisualizacaoDTO;
+import com.acadmap.model.dto.veiculo.FiltroVeiculoRequestDTO;
 import com.acadmap.model.entities.Periodico;
 import com.acadmap.model.enums.StatusVeiculo;
 import com.acadmap.repository.PeriodicoRepository;
+import com.acadmap.specification.VeiculoSpecification;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,6 +15,7 @@ import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -21,6 +24,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class PeriodicoConsultaService {
 
   private final PeriodicoRepository periodicoRepository;
+  private final VeiculoSpecification veiculoSpecification;
 
   public PeriodicoVisualizacaoDTO consultaPorId(UUID id) {
     Optional<Periodico> periodicoOpt = this.periodicoRepository.findById(id);
@@ -51,4 +55,15 @@ public class PeriodicoConsultaService {
             .map(PeriodicoResumoListaDTO::new)
             .collect(Collectors.toList());
   }
+
+  public List<PeriodicoResumoListaDTO> listarComFiltros(FiltroVeiculoRequestDTO filtro) {
+    Specification<Periodico> periodicoSpec = veiculoSpecification.getSpecification(filtro);
+
+    List<Periodico> periodicos = periodicoRepository.findAll(periodicoSpec);
+
+    return periodicos.stream()
+            .map(PeriodicoResumoListaDTO::new)
+            .collect(Collectors.toList());
+  }
+
 }

--- a/backend/src/main/java/com/acadmap/service/specification/VeiculoSpecification.java
+++ b/backend/src/main/java/com/acadmap/service/specification/VeiculoSpecification.java
@@ -1,4 +1,4 @@
-package com.acadmap.specification;
+package com.acadmap.service.specification;
 
 import com.acadmap.model.dto.veiculo.FiltroVeiculoRequestDTO;
 import com.acadmap.model.entities.VeiculoPublicacao;
@@ -15,7 +15,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Component
 public class VeiculoSpecification {
@@ -43,13 +42,10 @@ public class VeiculoSpecification {
             }
 
             if (filtro.getAreasPesquisaIds() != null && !filtro.getAreasPesquisaIds().isEmpty()) {
-                // O 'join' é usado para fazer a ligação com a tabela de relacionamento
                 filtroPredicates.add(root.join("areasPesquisa").get("idAreaPesquisa").in(filtro.getAreasPesquisaIds()));
             }
 
             if (filtro.getAreasPesquisaNomes() != null && !filtro.getAreasPesquisaNomes().isEmpty()) {
-                // O 'join' cria a ligação com a tabela de AreaPesquisa
-                // A cláusula 'in' verifica se o nome da área está na lista fornecida
                 filtroPredicates.add(root.join("areasPesquisa").get("nome").in(filtro.getAreasPesquisaNomes()));
             } else if (filtro.getAreasPesquisaIds() != null && !filtro.getAreasPesquisaIds().isEmpty()) {
                 filtroPredicates.add(root.join("areasPesquisa").get("idAreaPesquisa").in(filtro.getAreasPesquisaIds()));

--- a/backend/src/main/java/com/acadmap/specification/VeiculoSpecification.java
+++ b/backend/src/main/java/com/acadmap/specification/VeiculoSpecification.java
@@ -1,0 +1,103 @@
+package com.acadmap.specification;
+
+import com.acadmap.model.dto.veiculo.FiltroVeiculoRequestDTO;
+import com.acadmap.model.entities.VeiculoPublicacao;
+import com.acadmap.model.enums.AdequacaoDefesa;
+import com.acadmap.model.enums.ClassificacaoVeiculo;
+import com.acadmap.model.enums.StatusVeiculo;
+import com.acadmap.model.enums.VinculoSBC;
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class VeiculoSpecification {
+
+    // Lista ordenada para o filtro de classificação mínima
+    private static final List<ClassificacaoVeiculo> CLASSIFICACAO_ORDER = Arrays.asList(
+            ClassificacaoVeiculo.a8, ClassificacaoVeiculo.a7, ClassificacaoVeiculo.a6,
+            ClassificacaoVeiculo.a5, ClassificacaoVeiculo.a4, ClassificacaoVeiculo.a3,
+            ClassificacaoVeiculo.a2, ClassificacaoVeiculo.a1
+    );
+
+    public <T extends VeiculoPublicacao> Specification<T> getSpecification(FiltroVeiculoRequestDTO filtro) {
+        return (root, query, criteriaBuilder) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            // Filtro base para status "aceito" sempre aplicado
+            predicates.add(criteriaBuilder.equal(root.get("status"), StatusVeiculo.aceito));
+
+            List<Predicate> filtroPredicates = new ArrayList<>();
+
+            // --- Lógica de Filtros ---
+
+            if (filtro.getNome() != null && !filtro.getNome().trim().isEmpty()) {
+                filtroPredicates.add(criteriaBuilder.like(criteriaBuilder.lower(root.get("nome")), "%" + filtro.getNome().toLowerCase() + "%"));
+            }
+
+            if (filtro.getAreasPesquisaIds() != null && !filtro.getAreasPesquisaIds().isEmpty()) {
+                // O 'join' é usado para fazer a ligação com a tabela de relacionamento
+                filtroPredicates.add(root.join("areasPesquisa").get("idAreaPesquisa").in(filtro.getAreasPesquisaIds()));
+            }
+
+            if (filtro.getAreasPesquisaNomes() != null && !filtro.getAreasPesquisaNomes().isEmpty()) {
+                // O 'join' cria a ligação com a tabela de AreaPesquisa
+                // A cláusula 'in' verifica se o nome da área está na lista fornecida
+                filtroPredicates.add(root.join("areasPesquisa").get("nome").in(filtro.getAreasPesquisaNomes()));
+            } else if (filtro.getAreasPesquisaIds() != null && !filtro.getAreasPesquisaIds().isEmpty()) {
+                filtroPredicates.add(root.join("areasPesquisa").get("idAreaPesquisa").in(filtro.getAreasPesquisaIds()));
+            }
+
+            if (filtro.getVinculoSbc() != null) {
+                if (filtro.getVinculoSbc()) {
+                    // Se vinculoSbc for true, busca todos que NÃO são "sem_vinculo"
+                    filtroPredicates.add(criteriaBuilder.notEqual(root.get("vinculoSbc"), VinculoSBC.sem_vinculo));
+                } else {
+                    // Se for false, busca apenas os que são "sem_vinculo"
+                    filtroPredicates.add(criteriaBuilder.equal(root.get("vinculoSbc"), VinculoSBC.sem_vinculo));
+                }
+            }
+
+            if (filtro.getAdequacaoDefesa() != null && !filtro.getAdequacaoDefesa().isEmpty()) {
+                Set<AdequacaoDefesa> adequacoes = new HashSet<>(filtro.getAdequacaoDefesa());
+                // Se o filtro inclui mestrado ou doutorado, também devemos incluir "mestrado_doutorado"
+                if (adequacoes.contains(AdequacaoDefesa.mestrado) || adequacoes.contains(AdequacaoDefesa.doutorado)) {
+                    adequacoes.add(AdequacaoDefesa.mestrado_doutorado);
+                }
+                filtroPredicates.add(root.get("adequadoDefesa").in(adequacoes));
+            }
+
+            if (filtro.getH5Minimo() != null) {
+                filtroPredicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get("h5"), filtro.getH5Minimo()));
+            }
+
+            if (filtro.getClassificacaoMinima() != null) {
+                int index = CLASSIFICACAO_ORDER.indexOf(filtro.getClassificacaoMinima());
+                if (index != -1) {
+                    List<ClassificacaoVeiculo> classificacoesValidas = CLASSIFICACAO_ORDER.subList(index, CLASSIFICACAO_ORDER.size());
+                    filtroPredicates.add(root.get("classificacao").in(classificacoesValidas));
+                }
+            }
+
+            // --- Combinação dos Predicados ---
+            if (!filtroPredicates.isEmpty()) {
+                Predicate combinedFilters;
+                if (filtro.isCorrespondenciaExata()) { // Lógica AND
+                    combinedFilters = criteriaBuilder.and(filtroPredicates.toArray(new Predicate[0]));
+                } else { // Lógica OR
+                    combinedFilters = criteriaBuilder.or(filtroPredicates.toArray(new Predicate[0]));
+                }
+                predicates.add(combinedFilters);
+            }
+
+            return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}


### PR DESCRIPTION
Adicionada a lógica de filtros dinâmicos para pesquisa de periódicos e eventos.
Substitui o GET anterior para pesquisa de periódicos e eventos por um POST que envia os filtros no body da requisição.
Os campos dos filtros estão listados no endpoint.