### PR TITLE
feat: novas acoes csv e grafico

### DIFF
--- a/backend/docker-volumes/scripts-sql/01_init.sql
+++ b/backend/docker-volumes/scripts-sql/01_init.sql
@@ -75,7 +75,10 @@ CREATE TABLE Log (
     'cadastro_veiculo_recusado',
     'cadastro_veiculo_aceito',
     'cadastro_usuario',
-    'exclusao_usuario'
+    'exclusao_usuario',
+    'geracao_csv',
+    'geracao_grafico',
+    'erro_grafico'
   ))
 );
 

--- a/backend/src/main/java/com/acadmap/model/enums/AcaoLog.java
+++ b/backend/src/main/java/com/acadmap/model/enums/AcaoLog.java
@@ -4,11 +4,16 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 
 public enum AcaoLog {
 
-  adicao_veiculo("adicao_veiculo"), exclusao_veiculo("exclusao_veiculo"), atualizacao_veiculo(
-      "atualizacao_veiculo"), cadastro_veiculo_recusado(
-          "cadastro_veiculo_recusado"), cadastro_veiculo_aceito(
-              "cadastro_veiculo_aceito"), cadastro_usuario(
-                  "cadastro_usuario"), exclusao_usuario("exclusao_usuario");
+  adicao_veiculo("adicao_veiculo"),
+  exclusao_veiculo("exclusao_veiculo"),
+  atualizacao_veiculo("atualizacao_veiculo"),
+  cadastro_veiculo_recusado("cadastro_veiculo_recusado"),
+  cadastro_veiculo_aceito("cadastro_veiculo_aceito"),
+  cadastro_usuario("cadastro_usuario"),
+  exclusao_usuario("exclusao_usuario"),
+  geracao_csv("geracao_csv"),
+  geracao_grafico("geracao_grafico"),
+  erro_grafico("erro_grafico");
 
   private String codigo;
 


### PR DESCRIPTION
Para valos permitidos em acao no log foram adicionados os seguites itens:
- `geracao_csv`
- `geracao_grafico`
-  `erro_grafico`